### PR TITLE
Fix visualization not working on top of transparent blocks

### DIFF
--- a/bukkit-20R1/pom.xml
+++ b/bukkit-20R1/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit</artifactId>
-            <version>1.20-R0.1-SNAPSHOT</version>
+            <version>1.20.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bukkit-20R4/pom.xml
+++ b/bukkit-20R4/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit</artifactId>
-            <version>1.20.5-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/bukkit-21R1/pom.xml
+++ b/bukkit-21R1/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>craftbukkit</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/plugin/src/main/java/dev/cerus/visualcrafting/plugin/visualizer/DisplayVisualizationController.java
+++ b/plugin/src/main/java/dev/cerus/visualcrafting/plugin/visualizer/DisplayVisualizationController.java
@@ -36,7 +36,7 @@ public class DisplayVisualizationController implements VisualizationController {
 
     @Override
     public void recipeSelected(final ItemStack[] matrix, final ItemStack result, final Player actor, final Block craftingTable) {
-        if (craftingTable.getRelative(BlockFace.UP).getType() != Material.AIR) {
+        if (!craftingTable.getRelative(BlockFace.UP).getType().isTransparent()) {
             return;
         }
 

--- a/plugin/src/main/java/dev/cerus/visualcrafting/plugin/visualizer/MapVisualizationController.java
+++ b/plugin/src/main/java/dev/cerus/visualcrafting/plugin/visualizer/MapVisualizationController.java
@@ -77,7 +77,7 @@ public class MapVisualizationController implements VisualizationController {
      */
     @Override
     public void recipeSelected(final ItemStack[] matrix, final ItemStack result, final Player actor, final Block craftingTable) {
-        if (craftingTable.getRelative(BlockFace.UP).getType() != Material.AIR) {
+        if (!craftingTable.getRelative(BlockFace.UP).getType().isTransparent()) {
             return;
         }
 


### PR DESCRIPTION
This PR fixes #6 by relaxing the limitation from not rendering the visualization for anything not the `AIR` material, to anything that is a "transparent" material (which at the very least includes air, torches, redstone torches, and end rods).

Note that according to the [Spigot javadocs for `Material#isTransparent`](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html#isTransparent()) (in 1.21.1 at time of writing), the method is deprecated because the method "currently does not have an implementation which is well linked to the underlying server" (which I'm not sure what that means). One possible alternative which I did not test was a nearby method [`Material#isOccluding()`](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html#isOccluding()), but I'm not sure how much that would fit.

See the following screenshot for the amended code in action:

![Image of a crafting recipe being visualized in world, even though a torch is placed over the crafting table](https://github.com/user-attachments/assets/6a666745-96c9-4b36-9adb-02d53e971e34)

(Note that the torch has to be placed _before_ the crafting recipe is completed, since the visualization only updates when the crafting recipe is changed.)

---

To setup the project (after some difficulty in learning/remembering how to setup the environment for plugin development; last time I touched Bukkit stuff seriously was before the whole DMCA sitution 😅), I had to adjust the following versions in the relevant POMs (which is documented in a separate commit):

- For `bukkit-20R1`, from `1.20-R0.1-SNAPSHOT` to `1.20.1-R0.1-SNAPSHOT`.
- For `bukkit-20R4`, from `1.20.5-R0.1-SNAPSHOT` to `1.20.6-R0.1-SNAPSHOT`
- For `bukkit-21R1`, from `1.21-R0.1-SNAPSHOT` to `1.21.1-R0.1-SNAPSHOT`

As far as I can tell, these changes should be benign as the difference between those versions are a couple of hotfixes for critical bugs. A cursory comparison of the class bytecode for the resulting plugin JAR (compared to the one in https://github.com/cerus/visual-crafting/releases/tag/1.3.4) shows no differences. 

That change should be a net positive, since it helps out developers starting fresh in the future, without having built 1.20/1.20.5/1.21 previously before BuildTools was amended (I presume) to redirect any attempts to build those versions with their hotfixed counterparts.